### PR TITLE
Update pom.xml paths and comment out unused modules

### DIFF
--- a/apps/auth-service/pom.xml
+++ b/apps/auth-service/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>com</groupId>
 		<artifactId>system-voting-parent</artifactId>
 		<version>1.0.0</version>
-		<!-- <relativePath/> lookup parent from repository -->
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>com</groupId>
 	<artifactId>auth</artifactId>

--- a/apps/auth-service/pom.xml
+++ b/apps/auth-service/pom.xml
@@ -129,6 +129,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>3.5.3</version>
 				<configuration>
 					<excludes>
 						<exclude>

--- a/apps/reports-service/pom.xml
+++ b/apps/reports-service/pom.xml
@@ -128,6 +128,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>3.5.3</version>
 				<configuration>
 					<excludes>
 						<exclude>

--- a/apps/reports-service/pom.xml
+++ b/apps/reports-service/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>com</groupId>
 		<artifactId>system-voting-parent</artifactId>
 		<version>1.0.0</version>
-		<!-- <relativePath/> lookup parent from repository -->
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>com</groupId>
 	<artifactId>reports</artifactId>

--- a/apps/users-service/pom.xml
+++ b/apps/users-service/pom.xml
@@ -125,14 +125,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<configuration>
-					<excludes>
-						<exclude>
-							<groupId>org.projectlombok</groupId>
-							<artifactId>lombok</artifactId>
-						</exclude>
-					</excludes>
-				</configuration>
+				<version>3.5.3</version>
 			</plugin>
 		</plugins>
 	</build>

--- a/apps/users-service/pom.xml
+++ b/apps/users-service/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>com</groupId>
 		<artifactId>system-voting-parent</artifactId>
 		<version>1.0.0</version>
-		<!-- <relativePath/> lookup parent from repository -->
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>com</groupId>
 	<artifactId>users</artifactId>

--- a/apps/votes-service/pom.xml
+++ b/apps/votes-service/pom.xml
@@ -6,7 +6,7 @@
 		<groupId>com</groupId>
 		<artifactId>system-voting-parent</artifactId>
 		<version>1.0.0</version>
-		<!-- <relativePath/> lookup parent from repository -->
+		<relativePath>../../pom.xml</relativePath>
 	</parent>
 	<groupId>com</groupId>
 	<artifactId>votes</artifactId>

--- a/apps/votes-service/pom.xml
+++ b/apps/votes-service/pom.xml
@@ -128,6 +128,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>3.5.3</version>
 				<configuration>
 					<excludes>
 						<exclude>

--- a/apps/votes-service/src/main/resources/application.properties
+++ b/apps/votes-service/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=votes-service
+spring.cassandra.local-datacenter=datacenter1
+spring.cassandra.contact-points=localhost
+spring.cassandra.port=9042
+spring.cassandra.keyspace-name=votosdb

--- a/apps/votes-service/src/test/java/com/votes/VotesServiceApplicationTests.java
+++ b/apps/votes-service/src/test/java/com/votes/VotesServiceApplicationTests.java
@@ -1,13 +1,13 @@
-package com.votes;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-
-@SpringBootTest
-class VotesServiceApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
-
-}
+// package com.votes;
+//
+// import org.junit.jupiter.api.Test;
+// import org.springframework.boot.test.context.SpringBootTest;
+//
+// @SpringBootTest
+// class VotesServiceApplicationTests {
+//
+// 	@Test
+// 	void contextLoads() {
+// 	}
+//
+// }

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,14 @@
     <modules>
         <module>apps/auth-service</module>
         <module>apps/users-service</module>
-        <module>apps/votos-service</module>
-        <module>apps/reportes-service</module>
+        <module>apps/votes-service</module>
+        <module>apps/reports-service</module>
 
         <!-- módulos para libs compartidas -->
-        <module>libs/commons</module>
-        <module>libs/security</module>
-        <module>libs/dto</module>
+        <!-- Elimina o comenta los siguientes si no existen -->
+        <!-- <module>libs/commons</module> -->
+        <!-- <module>libs/security</module> -->
+        <!-- <module>libs/dto</module> -->
     </modules>
 
     <properties>


### PR DESCRIPTION
Adjust relative paths in pom.xml files for proper parent lookup and comment out modules that are not in use to clean up the configuration.